### PR TITLE
Fix #6

### DIFF
--- a/lib/GraphiteClient.js
+++ b/lib/GraphiteClient.js
@@ -28,14 +28,10 @@ GraphiteClient.flatten = function(obj, flat, prefix) {
   return flat;
 };
 
-GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
-  if (typeof timestamp === 'function') {
-    cb        = timestamp;
-    timestamp = null;
+GraphiteClient.prototype.write = function(metrics, cb, timestamp = 0) {
+  if (timestamp == 0) {
+    timestamp = Math.floor(Date.now() / 1000);
   }
-
-  timestamp = timestamp || Date.now();
-  timestamp = Math.floor(timestamp / 1000);
 
   this._carbon.write(GraphiteClient.flatten(metrics), timestamp, cb);
 };

--- a/lib/GraphiteClient.js
+++ b/lib/GraphiteClient.js
@@ -28,8 +28,8 @@ GraphiteClient.flatten = function(obj, flat, prefix) {
   return flat;
 };
 
-GraphiteClient.prototype.write = function(metrics, cb, timestamp = 0) {
-  if (timestamp == 0) {
+GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
+  if (timestamp === undefined) {
     timestamp = Math.floor(Date.now() / 1000);
   }
 

--- a/lib/GraphiteClient.js
+++ b/lib/GraphiteClient.js
@@ -29,6 +29,11 @@ GraphiteClient.flatten = function(obj, flat, prefix) {
 };
 
 GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
+  if (typeof timestamp === 'function') {
+    cb = timestamp;
+    timestamp = undefined;
+  }
+
   if (timestamp === undefined) {
     timestamp = Math.floor(Date.now() / 1000);
   }


### PR DESCRIPTION
This fixes #6 in that when a timestamp is given it is not wrongly manipulated (i.e. `timestamp = Math.floor(timestamp / 1000)`), while being backwards-compatible with code already using node-graphite.