### PR TITLE
Implement tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ client.write(metrics, function(err) {
 });
 ```
 
+Sending data with tags:
+
+```js
+var graphite = require('graphite');
+var client = graphite.createClient('plaintext://graphite.example.org:2003/');
+
+var metrics = {foo: 23};
+var tags = {'name': 'foo.bar', 'some.fancy.tag': 'somefancyvalue'};
+client.writeTagged(metrics, tags, function(err) {
+  // if err is null, your data was sent to graphite!
+});
+```
+
 ## Todo
 
 * More docs

--- a/lib/GraphiteClient.js
+++ b/lib/GraphiteClient.js
@@ -28,6 +28,22 @@ GraphiteClient.flatten = function(obj, flat, prefix) {
   return flat;
 };
 
+GraphiteClient.appendTags = function(flatMetrics, tags) {
+  tagSuffix = '';
+  res = {};
+
+  flatTags = GraphiteClient.flatten(tags);
+  for (var key in flatTags) {
+    tagSuffix += ';' + key + '=' + flatTags[key];
+  }
+
+  for (var key in flatMetrics) {
+    res[key + tagSuffix] = flatMetrics[key];
+  }
+
+  return res;
+}
+
 GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
   if (typeof timestamp === 'function') {
     cb        = timestamp;
@@ -39,6 +55,11 @@ GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
 
   this._carbon.write(GraphiteClient.flatten(metrics), timestamp, cb);
 };
+
+GraphiteClient.prototype.writeTagged = function(metrics, tags, timestamp, cb) {
+  taggedMetrics = appendTags(GraphiteClient.flatten(metrics), tags);
+  this.write(taggedMetrics, timestamp, cb);
+}
 
 GraphiteClient.prototype.end = function() {
   this._carbon.end();

--- a/lib/GraphiteClient.js
+++ b/lib/GraphiteClient.js
@@ -42,7 +42,7 @@ GraphiteClient.appendTags = function(flatMetrics, tags) {
   }
 
   return res;
-}
+};
 
 GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
   if (typeof timestamp === 'function') {
@@ -57,7 +57,7 @@ GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
 };
 
 GraphiteClient.prototype.writeTagged = function(metrics, tags, timestamp, cb) {
-  taggedMetrics = appendTags(GraphiteClient.flatten(metrics), tags);
+  taggedMetrics = GraphiteClient.appendTags(GraphiteClient.flatten(metrics), tags);
   this.write(taggedMetrics, timestamp, cb);
 }
 


### PR DESCRIPTION
In Graphite [1.1.1 (21.12.17)](http://graphite.readthedocs.io/en/latest/releases/1_1_1.html), [tagging](http://graphite.readthedocs.io/en/latest/tags.html) becomes available.

This commit is to bring support for tagging when writing metrics to Graphite.