### PR TITLE
Set default timestamp when both time and callback are omitted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: node_js
 node_js:
   - 0.4
   - 0.6
+  - 4
+  - 8

--- a/lib/GraphiteClient.js
+++ b/lib/GraphiteClient.js
@@ -59,8 +59,11 @@ GraphiteClient.appendTags = function(flatMetrics, tags) {
 GraphiteClient.prototype.write = function(metrics, timestamp, cb) {
   if (typeof timestamp === 'function') {
     cb = timestamp;
-    timestamp = Date.now();
+    timestamp = null;
   }
+
+  // default timestamp to now
+  timestamp = timestamp || Date.now();
 
   // cutting timestamp for precision up to the second
   timestamp = Math.floor(timestamp / 1000);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "main": "./index",
   "scripts": {
-    "test": "make test"
+    "test": "npm run test:unit && npm run test:integration",
+    "test:unit": "make test type=unit",
+    "test:integration": "make test type=integration"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
- Set default timestamp when both time and callback are omitted
- Set travis testing on later node versions
- Make package.json run `make` tests using npm test
Fixes #10